### PR TITLE
Add shared_chest

### DIFF
--- a/plugins/shared_chest.rb
+++ b/plugins/shared_chest.rb
@@ -1,0 +1,50 @@
+import 'org.bukkit.Bukkit'
+import 'org.bukkit.event.block.Action'
+import 'org.bukkit.Material'
+import 'org.bukkit.block.BlockFace'
+import 'org.bukkit.entity.ItemFrame'
+
+module SharedChest
+  extend self
+  extend Rukkit::Util
+
+  def create_shared_chest(block)
+    block.type = Material::CHEST
+    block.data = 0
+    [
+      BlockFace::UP,
+      BlockFace::NORTH,
+      BlockFace::SOUTH,
+      BlockFace::EAST,
+      BlockFace::WEST,
+    ].each do |face|
+      b = block.get_relative(face)
+      b.type = Material::BEDROCK
+      b.data = 0
+    end
+  end
+
+  def shared_chest_inventory
+    chest = Bukkit.get_world('world').get_block_at(0, 0, 0)
+    if chest.type != Material::CHEST
+      create_shared_chest(chest)
+    end
+    chest.state.block_inventory
+  end
+
+  def shared_chest?(entity)
+    case entity
+    when ItemFrame
+      entity.item.type == Material::CHEST
+    else
+      false
+    end
+  end
+
+  def on_player_interact_entity(evt)
+    return unless shared_chest?(evt.right_clicked)
+    evt.cancelled = true
+    evt.player.open_inventory(shared_chest_inventory)
+  end
+
+end


### PR DESCRIPTION
全ユーザー共有チェスト機能を作ってみました。
### 使い方

黒曜石の上にチェストを置くと、それは共有チェストになります。
### 制限

割と実装は手抜きなので、制限があります。
- 中身を見ている間でもチェストの蓋が開かない。(開ける方法知ってる人いたら教えてください)
- チェストを2つ繋げた場合、真下に黒曜石があるかどうかしか見てないので、クリックした位置によって共有になったりならなかったりする。
  - これは将来、隣にもチェストがあったら(=大きいチェストだったら)共有にしないなどの制限を設けたい。
### 裏の挙動

ワールドの 0, 0, 0 にチェストが作成され、そのチェストが共有チェストとして使われます。
このチェストの周囲は岩盤で囲まれます。
### 備考

ローカルのシングルプレイヤーで動作を確認しました。
マルチプレイヤーでは確認してません。
