### PR TITLE
re-assign constant fixed #22

### DIFF
--- a/plugins/player_job_farmer.rb
+++ b/plugins/player_job_farmer.rb
@@ -8,7 +8,7 @@ module PlayerJobFarmer
   extend Rukkit::Util
   extend PlayerJob
 
-  CROP_STATE = [
+  @crop_state = [
     CropState::SEEDED,
     CropState::GERMINATED,
     CropState::VERY_SMALL,
@@ -41,7 +41,7 @@ module PlayerJobFarmer
         case state.data
         when Crops
           if state.data.state != CropState::RIPE
-            next_state = CROP_STATE[CROP_STATE.index(state.data.state) + 1]
+            next_state = @crop_state[@crop_state.index(state.data.state) + 1]
             state.data.state = next_state
             state.update
           end


### PR DESCRIPTION
issues #22 の対応で、定数からメンバ変数に変更してwarningが出ないようにしました。
正直何でmoduleが２回読み込まれるかよくわかっておらず、何か他にいい方法あったら教えていただけると助かります。