### PR TITLE
ジョブチェンジの追加

### DIFF
--- a/config.yml.sample
+++ b/config.yml.sample
@@ -23,6 +23,7 @@ rukkit:
     - player_job_smith
     - player_job_woodcutter
     - player_job_legion
+    - player_job_change
     - safe_login
     - dirt_to_clay_recipe
     - cow_diamond

--- a/plugins/player_job_change.rb
+++ b/plugins/player_job_change.rb
@@ -1,0 +1,71 @@
+# encoding: utf-8
+import 'org.bukkit.entity.Player'
+import 'org.bukkit.Material'
+
+module PlayerJobChange
+  extend self
+  extend Rukkit::Util
+
+  JOB_SYMBOL = {
+    Material::ANVIL          => PlayerJobSmith,
+    Material::IRON_SWORD     => PlayerJobKnight,
+    Material::IRON_PLATE     => PlayerJobLegion,
+    Material::IRON_HOE       => PlayerJobFarmer,
+    Material::COOKED_CHICKEN => PlayerJobFighter,
+    Material::IRON_AXE       => PlayerJobWoodcutter,
+    Material::WATER_BUCKET   => PlayerJobSeaman,
+  }
+
+  FACE_MAP = {
+    BlockFace::EAST  => BlockFace::WEST,
+    BlockFace::WEST  => BlockFace::EAST,
+    BlockFace::NORTH => BlockFace::SOUTH,
+    BlockFace::SOUTH => BlockFace::NORTH,
+  }
+
+  def on_entity_damage_by_entity(evt)
+    damager = evt.damager
+    return unless Player === damager
+    entity = evt.entity
+    return unless entity.type == EntityType::ITEM_FRAME
+    return unless JOB_SYMBOL[entity.item.type]
+    facing = FACE_MAP[entity.facing]
+    return unless entity.location.block.get_relative(facing).type == Material::QUARTZ_BLOCK
+
+    evt.cancelled = true
+
+    job_class = JOB_SYMBOL[entity.item.type]
+    job = PlayerJob.find(&job_class.method(:===))
+    @attack_count ||= {}
+    @attack_count[damager.entity_id] ||= {}
+    @attack_count[damager.entity_id][entity.item.type.id] ||= 0
+    case @attack_count[damager.entity_id][entity.item.type.id]
+    when 0
+      if job.has_job?(damager)
+        unless @noticed
+          damager.send_message("すでに#{job.name}だ")
+          @noticed = true
+          later sec(10) do
+            @noticed = false
+          end
+        end
+        return
+      end
+
+      damager.send_message("#{job.name}になりたければ続けよ")
+      later sec(10) do
+        @attack_count[damager.entity_id][entity.item.type.id] = 0
+      end
+    when 10
+      PlayerJob.each do |j|
+        j.unregister(damager)
+      end
+      job.register(damager)
+
+      damager.send_message("今からお前は#{job.name}だ おめでとう！")
+
+      @attack_count[damager.entity_id][entity.item.type.id] = 0
+    end
+    @attack_count[damager.entity_id][entity.item.type.id] += 1
+  end
+end

--- a/plugins/player_job_farmer.rb
+++ b/plugins/player_job_farmer.rb
@@ -31,6 +31,10 @@ module PlayerJobFarmer
     "#{evt.player.name}さんが農家になりました(空気中で鍬を振ると周りの作物が成長。範囲耕し、範囲種植が可能)"
   end
 
+  def name
+    '農家'
+  end
+
   def detail
     '[農家]:空気中で鍬を振ると周りの作物が成長。範囲耕しが可能'
   end

--- a/plugins/player_job_fighter.rb
+++ b/plugins/player_job_fighter.rb
@@ -9,6 +9,10 @@ module PlayerJobFighter
     "#{evt.player.name}さんが武闘家になりました(装備なし、手持ちなしで攻撃と防御が強くなります。裸足のときのみノーダメージ着地可能)"
   end
 
+  def name
+    '武闘家'
+  end
+
   def detail
     '[武闘家]:装備なし、手持ちなしで攻撃と防御が強くなります。裸足のときのみノーダメージ着地可能'
   end

--- a/plugins/player_job_knight.rb
+++ b/plugins/player_job_knight.rb
@@ -9,6 +9,10 @@ module PlayerJobKnight
     "#{evt.player.name}さんが剣士になりました(剣の攻撃と防御が強くなります)"
   end
 
+  def name
+    '剣士'
+  end
+
   def detail
     '[剣士]:剣の攻撃と防御が強くなります'
   end

--- a/plugins/player_job_legion.rb
+++ b/plugins/player_job_legion.rb
@@ -14,6 +14,10 @@ module PlayerJobLegion
     "#{evt.player.name}さんが古代ローマ市民になりました (鉄装備で固めるとローマの栄光を得ます)"
   end
 
+  def name
+    '古代ローマ市民'
+  end
+
   def detail
     '[古代ローマ市民]:鉄装備で固めるとローマの栄光を得ます'
   end

--- a/plugins/player_job_seaman.rb
+++ b/plugins/player_job_seaman.rb
@@ -9,6 +9,10 @@ module PlayerJobSeaman
     "#{evt.player.name}さんが海士になりました(海に入っても溺れない)"
   end
 
+  def name
+    '海士'
+  end
+
   def detail
     '[海士]:海に入っても溺れない'
   end

--- a/plugins/player_job_smith.rb
+++ b/plugins/player_job_smith.rb
@@ -9,6 +9,10 @@ module PlayerJobSmith
     "#{evt.player.name}さんが鍛冶屋になりました(空気中で剣、斧などを振ると耐久力回復)"
   end
 
+  def name
+    '鍛冶屋'
+  end
+
   def detail
     '[鍛冶屋]:空気中で剣、斧などを振ると耐久力回復'
   end

--- a/plugins/player_job_woodcutter.rb
+++ b/plugins/player_job_woodcutter.rb
@@ -11,6 +11,10 @@ module PlayerJobWoodcutter
     "#{evt.player.name}さんが木こりになりました(斧で木を切るのが早くなります)"
   end
 
+  def name
+    '木こり'
+  end
+
   def detail
     '[木こり]:斧で木を切るのが早くなります'
   end

--- a/scripts/player_job.rb
+++ b/scripts/player_job.rb
@@ -14,13 +14,15 @@ module PlayerJob
   @@job_plugins ||= []
 
   def on_player_join(evt)
-    player = evt.player
-
-    # become job with 30% of probability
     @players ||= Set.new
-    @players.add(player.entity_id) if rand(100) < 30
-    message = @message_proc.call(evt) if @message_proc
-    Rukkit::Util.broadcast(message) if message && has_job?(player)
+  end
+
+  def register(player)
+    @players && @players.add(player.entity_id)
+  end
+
+  def unregister(player)
+    @players && @players.delete(player.entity_id)
   end
 
   def on_player_quit(evt)


### PR DESCRIPTION
ジョブチェンジを追加しました。

ネザー水晶ブロックに額縁を貼り付けて、ジョブ固有のアイテムを額縁の中に入れると、
以降その額縁内のブロックを10回叩くことで、ジョブチェンジ出来るようになります。

ジョブ固有のアイテムは以下のとおり

|ジョブ名|ジョブ固有のアイテム|
|---|---|
|鍛冶屋|鉄床|
|剣士|鉄の剣|
|古代ローマ市民|鉄のプレート|
|農民|鉄の鍬|
|武闘家|焼き鳥|
|木こり|鉄の斧|
|海士|水バケツ|